### PR TITLE
Change client version requirement to be of the same year

### DIFF
--- a/events/loginEvent.py
+++ b/events/loginEvent.py
@@ -99,8 +99,8 @@ def handle(
             day=int(rgx["ver"][6:8]),
         )
 
-        # disallow clients older than 4 months
-        if osuVersion < (dt.now() - td(120)):
+        # disallow clients that aren't from the current year
+        if osuVersion.year != dt.now().year:
             log(f"Denied login from {osuVersionStr}.", Ansi.LYELLOW)
             raise exceptions.haxException()
 

--- a/events/loginEvent.py
+++ b/events/loginEvent.py
@@ -99,8 +99,8 @@ def handle(
             day=int(rgx["ver"][6:8]),
         )
 
-        # disallow clients that aren't from the current year
-        if osuVersion.year != dt.now().year:
+        # disallow clients older than 1 year
+        if osuVersion < (dt.now() - td(365)):
             log(f"Denied login from {osuVersionStr}.", Ansi.LYELLOW)
             raise exceptions.haxException()
 


### PR DESCRIPTION
Old requirement was a client date within 4 months, this is flawed as currently the latest stable release is over 4 months old.