### PR TITLE
Remove USER_PENDING_VERIFICATION from ban

### DIFF
--- a/common/ripple/userUtils.py
+++ b/common/ripple/userUtils.py
@@ -937,7 +937,7 @@ def ban(userID: int) -> None:
         "SET privileges = privileges & %s, "
         "ban_datetime = UNIX_TIMESTAMP() "
         "WHERE id = %s",
-        [~(privileges.USER_NORMAL | privileges.USER_PUBLIC), userID],
+        [~(privileges.USER_NORMAL | privileges.USER_PUBLIC | privileges.USER_PENDING_VERIFICATION), userID],
     )
 
     # Notify bancho about the ban


### PR DESCRIPTION
Removes USER_PENDING_VERIFICATION from banning, once a player gets banned they cannot be left as pending, otherwise it can be bypassed by reverifying.