### PR TITLE
fix: game_mode !=0 when AP is enabled & game_mode == 3 when RX is enabled

### DIFF
--- a/events/changeActionEvent.py
+++ b/events/changeActionEvent.py
@@ -64,7 +64,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
         should_update_cached_stats = True
 
     # prevents possible crashes on getUserStats where AP is enabled and game_mode != 0
-    if autopilot_in_mods:
+    if autopilot_in_mods and userToken["game_mode"] != 0:
         packetData["actionMods"] &= ~mods.AUTOPILOT
         should_update_cached_stats = True
 

--- a/events/changeActionEvent.py
+++ b/events/changeActionEvent.py
@@ -63,6 +63,11 @@ async def handle(userToken: Token, rawPacketData: bytes):
         userToken["game_mode"] = packetData["gameMode"]
         should_update_cached_stats = True
 
+    # prevents possible crashes on getUserStats where AP is enabled and game_mode != 0
+    if autopilot_in_mods:
+        userToken["game_mode"] = 0
+        should_update_cached_stats = True
+
     await osuToken.update_token(
         userToken["token_id"],
         relax=userToken["relax"],

--- a/events/changeActionEvent.py
+++ b/events/changeActionEvent.py
@@ -68,6 +68,11 @@ async def handle(userToken: Token, rawPacketData: bytes):
         userToken["game_mode"] = 0
         should_update_cached_stats = True
 
+    # prevents possible crashes on getUserStats where AP is enabled and game_mode is mania
+    if relax_in_mods and userToken["game_mode"] == 3:
+        userToken["game_mode"] = 0
+        should_update_cached_stats = True
+
     await osuToken.update_token(
         userToken["token_id"],
         relax=userToken["relax"],

--- a/events/changeActionEvent.py
+++ b/events/changeActionEvent.py
@@ -65,12 +65,12 @@ async def handle(userToken: Token, rawPacketData: bytes):
 
     # prevents possible crashes on getUserStats where AP is enabled and game_mode != 0
     if autopilot_in_mods:
-        userToken["game_mode"] = 0
+        packetData["actionMods"] &= ~mods.AUTOPILOT
         should_update_cached_stats = True
 
     # prevents possible crashes on getUserStats where AP is enabled and game_mode is mania
     if relax_in_mods and userToken["game_mode"] == 3:
-        userToken["game_mode"] = 0
+        packetData["actionMods"] &= ~mods.RELAX
         should_update_cached_stats = True
 
     await osuToken.update_token(

--- a/helpers/packetHelper.py
+++ b/helpers/packetHelper.py
@@ -127,7 +127,7 @@ def buildPacket(__packet: int, __packetData: tuple = ()) -> bytes:
 
 
 class PacketData(TypedDict):
-    data: Mapping[str, Any]
+    data: dict[str, Any]
     end: int
 
 


### PR DESCRIPTION
this is causing our pubsub daemon to crash and is also just a notorious bug that causes a crash when fetching stats. this seems like the easiest way to just alleviate the problem