### PR TITLE
General fixes and sanity checks to improve !mp commands

### DIFF
--- a/common/channel_utils.py
+++ b/common/channel_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 def get_client_name(name: str) -> str:
     if name.startswith("#spect_"):
         return "#spectator"
-    elif name.startswith("#multi_"):
+    elif name.startswith("#mp_"):
         return "#multiplayer"
     else:
         return name

--- a/constants/chatbotCommands.py
+++ b/constants/chatbotCommands.py
@@ -1742,7 +1742,8 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             raise exceptions.userNotFoundException("No such user")
 
         await match.remove_referee(
-            multiplayer_match["match_id"], target_token["user_id"],
+            multiplayer_match["match_id"],
+            target_token["user_id"],
         )
         return f"Removed {target_token['username']} from referees"
 
@@ -1800,7 +1801,8 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                 )
             else:
                 await osuToken.joinMatch(
-                    user_token["token_id"], multiplayer_match["match_id"],
+                    user_token["token_id"],
+                    multiplayer_match["match_id"],
                 )
 
             await match.setHost(multiplayer_match["match_id"], user_token["user_id"])
@@ -1937,7 +1939,9 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
 
         async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
             success = await match.userChangeSlot(
-                multiplayer_match["match_id"], target_token["user_id"], newSlotID,
+                multiplayer_match["match_id"],
+                target_token["user_id"],
+                newSlotID,
             )
 
         return (
@@ -1973,7 +1977,8 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
 
         async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
             success = match.setHost(
-                multiplayer_match["match_id"], target_token["user_id"],
+                multiplayer_match["match_id"],
+                target_token["user_id"],
             )
 
         return (
@@ -2346,7 +2351,8 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
 
         async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
             slot_id = await match.getUserSlotID(
-                multiplayer_match["match_id"], target_token["user_id"],
+                multiplayer_match["match_id"],
+                target_token["user_id"],
             )
             if not slot_id:
                 raise exceptions.userNotFoundException(

--- a/constants/chatbotCommands.py
+++ b/constants/chatbotCommands.py
@@ -2501,13 +2501,15 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if not username:
             raise exceptions.invalidArgumentsException("Please provide a username.")
 
+        colour_dict = {"red": matchTeams.RED, "blue": matchTeams.BLUE}
+
         colour = message[2].lower().strip()
-        if colour not in {"red", "blue"}:
+        colour_const = colour_dict.get(colour)
+
+        if colour_const is None:
             raise exceptions.invalidArgumentsException(
                 "Team colour must be red or blue.",
             )
-
-        colour_const = {"red": matchTeams.RED, "blue": matchTeams.BLUE}[colour]
 
         target_token = await osuToken.get_token_by_username(username)
         if not target_token:

--- a/constants/chatbotCommands.py
+++ b/constants/chatbotCommands.py
@@ -1838,7 +1838,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if user_token["user_id"] not in referees:
             return
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             await match.update_match(multiplayer_match["match_id"], is_locked=True)
 
         return "This match has been locked."
@@ -1855,7 +1855,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if user_token["user_id"] not in referees:
             return
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             await match.update_match(multiplayer_match["match_id"], is_locked=False)
 
         return "This match has been unlocked."
@@ -1882,7 +1882,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             )
         matchSize = int(message[1])
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             await match.forceSize(multiplayer_match["match_id"], matchSize)
 
         return f"Match size changed to {matchSize}."
@@ -1901,7 +1901,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if not userToken:
             raise exceptions.userNotFoundException("No such user.")
 
-        async with redisLock(f"{match.make_key(matchID)}:lock"):
+        async with redisLock(match.make_lock_key(matchID)):
             if not await osuToken.joinMatch(userToken["token_id"], matchID):
                 return "Failed to join match."
 
@@ -1936,7 +1936,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if not target_token:
             raise exceptions.userNotFoundException("No such user.")
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             success = await match.userChangeSlot(
                 multiplayer_match["match_id"],
                 target_token["user_id"],
@@ -1974,7 +1974,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if not target_token:
             raise exceptions.userNotFoundException("No such user.")
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             success = match.setHost(
                 multiplayer_match["match_id"],
                 target_token["user_id"],
@@ -1998,7 +1998,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if user_token["user_id"] not in referees:
             return
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             await match.removeHost(multiplayer_match["match_id"], rm_referee=False)
 
         return "Host has been removed from this match."
@@ -2219,7 +2219,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                 "order to cache it, then try again.",
             )
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             multiplayer_match = await match.update_match(
                 multiplayer_match["match_id"],
                 beatmap_id=beatmapID,
@@ -2274,7 +2274,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
 
         oldMatchTeamType = multiplayer_match["match_team_type"]
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             multiplayer_match = await match.update_match(
                 multiplayer_match["match_id"],
                 match_team_type=match_team_type,
@@ -2318,7 +2318,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if user_token["user_id"] not in referees:
             return
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             await match.abort(multiplayer_match["match_id"])
 
         return "Match aborted!"
@@ -2348,7 +2348,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if not target_token:
             raise exceptions.userNotFoundException("No such user.")
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             slot_id = await match.getUserSlotID(
                 multiplayer_match["match_id"],
                 target_token["user_id"],
@@ -2376,7 +2376,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if user_token["user_id"] not in referees:
             return
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             password = "" if len(message) < 2 or not message[1].strip() else message[1]
             await match.changePassword(multiplayer_match["match_id"], password)
 
@@ -2396,7 +2396,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if user_token["user_id"] not in referees:
             return
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             password = secrets.token_hex(16)
             await match.changePassword(multiplayer_match["match_id"], password)
 
@@ -2460,7 +2460,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             matchModModes.FREE_MOD if freemods else matchModModes.NORMAL
         )
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             multiplayer_match = await match.update_match(
                 multiplayer_match["match_id"],
                 match_mod_mode=new_match_mod_mode,
@@ -2515,7 +2515,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         if not target_token:
             raise exceptions.userNotFoundException("No such user.")
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             await match.changeTeam(
                 multiplayer_match["match_id"],
                 target_token["user_id"],
@@ -2614,7 +2614,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         else:
             new_scoring_type = matchScoringTypes.SCORE
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             multiplayer_match = await match.update_match(
                 multiplayer_match["match_id"],
                 match_scoring_type=new_scoring_type,

--- a/constants/chatbotCommands.py
+++ b/constants/chatbotCommands.py
@@ -1792,21 +1792,20 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             is_tourney=True,
         )
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
-            if user_token["irc"]:
-                await chat.joinChannel(  # join channel
-                    token_id=user_token["token_id"],
-                    channel_name=f"#mp_{multiplayer_match['match_id']}",
-                    force=True,
-                )
-            else:
-                await osuToken.joinMatch(
-                    user_token["token_id"],
-                    multiplayer_match["match_id"],
-                )
+        if user_token["irc"]:
+            await chat.joinChannel(  # join channel
+                token_id=user_token["token_id"],
+                channel_name=f"#mp_{multiplayer_match['match_id']}",
+                force=True,
+            )
+        else:
+            await osuToken.joinMatch(
+                user_token["token_id"],
+                multiplayer_match["match_id"],
+            )
 
-            await match.setHost(multiplayer_match["match_id"], user_token["user_id"])
-            await match.sendUpdates(multiplayer_match["match_id"])
+        await match.setHost(multiplayer_match["match_id"], user_token["user_id"])
+        await match.sendUpdates(multiplayer_match["match_id"])
 
         return f"Tourney match #{multiplayer_match['match_id']} created!"
 

--- a/constants/chatbotCommands.py
+++ b/constants/chatbotCommands.py
@@ -32,7 +32,6 @@ from constants import slotStatuses
 from helpers import chatHelper as chat
 from helpers import systemHelper
 from objects import channelList
-from objects.redisLock import redisLock
 from objects import chatbot
 from objects import glob
 from objects import match
@@ -41,6 +40,7 @@ from objects import osuToken
 from objects import slot
 from objects import streamList
 from objects import tokenList
+from objects.redisLock import redisLock
 
 """
 Commands callbacks
@@ -1742,7 +1742,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             raise exceptions.userNotFoundException("No such user")
 
         await match.remove_referee(
-            multiplayer_match["match_id"], target_token["user_id"]
+            multiplayer_match["match_id"], target_token["user_id"],
         )
         return f"Removed {target_token['username']} from referees"
 
@@ -1800,7 +1800,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                 )
             else:
                 await osuToken.joinMatch(
-                    user_token["token_id"], multiplayer_match["match_id"]
+                    user_token["token_id"], multiplayer_match["match_id"],
                 )
 
             await match.setHost(multiplayer_match["match_id"], user_token["user_id"])
@@ -1937,7 +1937,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
 
         async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
             success = await match.userChangeSlot(
-                multiplayer_match["match_id"], target_token["user_id"], newSlotID
+                multiplayer_match["match_id"], target_token["user_id"], newSlotID,
             )
 
         return (
@@ -1973,7 +1973,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
 
         async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
             success = match.setHost(
-                multiplayer_match["match_id"], target_token["user_id"]
+                multiplayer_match["match_id"], target_token["user_id"],
             )
 
         return (
@@ -2346,7 +2346,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
 
         async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
             slot_id = await match.getUserSlotID(
-                multiplayer_match["match_id"], target_token["user_id"]
+                multiplayer_match["match_id"], target_token["user_id"],
             )
             if not slot_id:
                 raise exceptions.userNotFoundException(
@@ -2630,7 +2630,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             return
 
         mp_message = await match.get_match_history_message(
-            multiplayer_match["match_id"]
+            multiplayer_match["match_id"],
         )
         return mp_message
 

--- a/constants/chatbotCommands.py
+++ b/constants/chatbotCommands.py
@@ -1677,86 +1677,111 @@ async def overwriteLatestScore(fro: str, chan: str, message: list[str]) -> str:
 async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
     """Contains many multiplayer subcommands (TODO: document them as well)."""
 
-    async def mpAddRefer():
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    _user_token = await osuToken.get_token_by_username(fro)
+    if _user_token is None:
+        return
+
+    if (
+        chan != "#multiplayer"
+        and not chan.startswith("#mp_")
+        and chan.lower() != glob.BOT_NAME.lower()
+    ):
+        return  # command used only on #multiplayer channels or bot PMs
+
+    async def mpAddRefer(user_token: osuToken.Token):
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if len(message) < 2:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp addref <user>",
             )
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
-
-        if not (username := message[1].strip()):
+        username = message[1].strip()
+        if not username:
             raise exceptions.invalidArgumentsException("Please provide a username")
 
-        if not (userID := await userUtils.getIDSafe(username)):
+        target_token = await osuToken.get_token_by_username(username)
+        if not target_token:
             raise exceptions.userNotFoundException("No such user")
-        await match.add_referee(multiplayer_match["match_id"], userID)
 
-        return f"Added {username} to referees"
+        await match.add_referee(multiplayer_match["match_id"], target_token["user_id"])
+        return f"Added {target_token['username']} to referees"
 
-    async def mpRemoveRefer() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpRemoveRefer(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if len(message) < 2:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp addref <user>",
             )
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
-
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
-
-        if not (username := message[1].strip()):
+        username = message[1].strip()
+        if not username:
             raise exceptions.invalidArgumentsException("Please provide a username")
 
-        if not (userID := await userUtils.getIDSafe(username)):
+        target_token = await osuToken.get_token_by_username(username)
+        if not target_token:
             raise exceptions.userNotFoundException("No such user")
 
-        await match.remove_referee(multiplayer_match["match_id"], userID)
-        return f"Removed {username} from referees"
+        await match.remove_referee(
+            multiplayer_match["match_id"], target_token["user_id"]
+        )
+        return f"Removed {target_token['username']} from referees"
 
-    async def mpListRefer() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpListRefer(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         ref_usernames: list[str] = []
-        for id in await match.get_referees(multiplayer_match["match_id"]):
-            username = await userUtils.getUsername(id)
+        for ref_id in referees:
+            username = await userUtils.getUsername(ref_id)
             assert username is not None
             ref_usernames.append(username)
 
         refs = ", ".join(ref_usernames)
         return f"Referees for this match: {refs}"
 
-    async def mpMake() -> Optional[str]:
-        if not (user_token := await osuToken.get_token_by_username(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpMake(user_token: osuToken.Token) -> Optional[str]:
+        if user_token["match_id"] is not None:
+            return "You are already in a match."
 
         if len(message) < 2:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp make <name>.",
             )
 
-        if not (matchName := " ".join(message[1:]).strip()):
+        match_name = " ".join(message[1:]).strip()
+        if not match_name:
             raise exceptions.invalidArgumentsException("Match name must not be empty!")
 
         multiplayer_match = await matchList.createMatch(
-            matchName,
+            match_name,
             match_password=secrets.token_hex(16),
             beatmap_id=0,
             beatmap_name="Tournament",
@@ -1767,11 +1792,6 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         )
 
         async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
-            # Add tourney creator as referee
-            await match.add_referee(
-                multiplayer_match["match_id"], user_token["user_id"]
-            )
-
             if user_token["irc"]:
                 await chat.joinChannel(  # join channel
                     token_id=user_token["token_id"],
@@ -1782,96 +1802,92 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                 await osuToken.joinMatch(
                     user_token["token_id"], multiplayer_match["match_id"]
                 )
+
+            await match.setHost(multiplayer_match["match_id"], user_token["user_id"])
             await match.sendUpdates(multiplayer_match["match_id"])
 
         return f"Tourney match #{multiplayer_match['match_id']} created!"
 
-    # def mpJoin() -> str:
-    #     if len(message) < 2 or not message[1].isnumeric():
-    #         raise exceptions.invalidArgumentsException(
-    #             "Incorrect syntax: !mp join <id>",
-    #         )
-    #     matchID = int(message[1])
-    #     userToken = await  tokenList.getTokenFromUsername(fro, ignoreIRC=True)
-    #     if userToken is None:
-    #         raise exceptions.invalidArgumentsException(
-    #             f"No game clients found for {fro}, can't join the match. "
-    #             "If you're a referee and you want to join the chat "
-    #             f"channel from IRC, use /join #mp_{matchID} instead.",
-    #         )
+    async def mpClose(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
 
-    #     await osuToken.joinMatch(userToken["token_id"], matchID)
-    #     return f"Attempting to join match #{matchID}!"
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
 
-    async def mpClose() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
-        matchID = await channelList.getMatchIDFromChannel(chan)
-        if userID not in await match.get_referees(matchID):
-            return None
+        await matchList.disposeMatch(multiplayer_match["match_id"])
+        return (
+            f"Multiplayer match #{multiplayer_match['match_id']} disposed successfully."
+        )
 
-        await matchList.disposeMatch(matchID)
-        return f"Multiplayer match #{matchID} disposed successfully."
+    async def mpLock(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
 
-    async def mpLock() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            await match.update_match(multiplayer_match["match_id"], is_locked=True)
 
-        await match.update_match(multiplayer_match["match_id"], is_locked=True)
         return "This match has been locked."
 
-    async def mpUnlock() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpUnlock(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
-        await match.update_match(multiplayer_match["match_id"], is_locked=False)
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            await match.update_match(multiplayer_match["match_id"], is_locked=False)
+
         return "This match has been unlocked."
 
-    async def mpSize() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpSize(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if (
             len(message) < 2
             or not message[1].isnumeric()
-            or int(message[1]) < 2
-            or int(message[1]) > 16
+            or not 2 <= int(message[1]) <= 16
         ):
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp size <slots(2-16)>.",
             )
         matchSize = int(message[1])
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            await match.forceSize(multiplayer_match["match_id"], matchSize)
 
-        await match.forceSize(multiplayer_match["match_id"], matchSize)
         return f"Match size changed to {matchSize}."
 
-    async def mpForce() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
-
-        froToken = await tokenList.getTokenFromUsername(fro, ignoreIRC=True)
-        if froToken is None:
-            return
-
-        if not froToken["privileges"] & privileges.ADMIN_CAKER:
+    async def mpForce(user_token: osuToken.Token) -> Optional[str]:
+        if not (user_token["privileges"] & privileges.ADMIN_CAKER):
             return
 
         if len(message) != 3 or not message[2].isnumeric():
@@ -1882,16 +1898,25 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
 
         userToken = await tokenList.getTokenFromUsername(username, ignoreIRC=True)
         if not userToken:
-            return
+            raise exceptions.userNotFoundException("No such user.")
 
-        if not await osuToken.joinMatch(userToken["token_id"], matchID):
-            return "Failed to join match."
+        async with redisLock(f"{match.make_key(matchID)}:lock"):
+            if not await osuToken.joinMatch(userToken["token_id"], matchID):
+                return "Failed to join match."
 
         return "Joined match."
 
-    async def mpMove() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpMove(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if (
             len(message) < 3
@@ -1906,74 +1931,88 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         username = message[1]
         newSlotID = int(message[2])
 
-        if not (userID := await userUtils.getIDSafe(username)):
+        target_token = await tokenList.getTokenFromUsername(username, ignoreIRC=True)
+        if not target_token:
             raise exceptions.userNotFoundException("No such user.")
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
-
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
-
-        success = match.userChangeSlot(multiplayer_match["match_id"], userID, newSlotID)
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            success = await match.userChangeSlot(
+                multiplayer_match["match_id"], target_token["user_id"], newSlotID
+            )
 
         return (
-            f"{username} moved to slot {newSlotID}."
+            f"{target_token['username']} moved to slot {newSlotID}."
             if success
             else "You can't use that slot: it's either already occupied by someone else or locked."
         )
 
-    async def mpHost() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpHost(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if len(message) < 2:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp host <username>.",
             )
 
-        if not (username := message[1].strip()):
+        username = message[1].strip()
+        if not username:
             raise exceptions.invalidArgumentsException("Please provide a username.")
 
-        if not (userID := await userUtils.getIDSafe(username)):
+        target_token = await tokenList.getTokenFromUsername(username)
+        if not target_token:
             raise exceptions.userNotFoundException("No such user.")
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            success = match.setHost(
+                multiplayer_match["match_id"], target_token["user_id"]
+            )
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
-
-        success = match.setHost(multiplayer_match["match_id"], userID)
         return (
-            f"{username} is now the host"
+            f"{target_token['username']} is now the host"
             if success
             else f"Couldn't give host to {username}."
         )
 
-    async def mpClearHost() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpClearHost(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
-        await match.removeHost(multiplayer_match["match_id"])
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            await match.removeHost(multiplayer_match["match_id"], rm_referee=False)
+
         return "Host has been removed from this match."
 
-    async def mpStart() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpStart(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         async def _start() -> bool:
-            multiplayer_match = await matchList.getMatchFromChannel(chan)
             assert multiplayer_match is not None
-
-            if userID not in await match.get_referees(multiplayer_match["match_id"]):
-                return False
 
             aika_token = await tokenList.getTokenFromUserID(CHATBOT_USER_ID)
             assert aika_token is not None
@@ -1993,9 +2032,6 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                     to=chan,
                     message="Have fun!",
                 )
-
-                token = await osuToken.get_token_by_user_id(userID)
-                assert token is not None
 
                 if glob.amplitude is not None:
                     amplitude_event_props = {
@@ -2027,8 +2063,8 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                     glob.amplitude.track(
                         BaseEvent(
                             event_type="start_multiplayer_match",
-                            user_id=str(userID),
-                            device_id=token["amplitude_device_id"],
+                            user_id=str(user_token["user_id"]),
+                            device_id=user_token["amplitude_device_id"],
                             event_properties=amplitude_event_props,
                         ),
                     )
@@ -2060,11 +2096,6 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             startTime = int(message[1])
 
         force = len(message) > 1 and message[1].lower() == "force"
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
-
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
 
         # Force everyone to ready
         someoneNotReady = False
@@ -2094,9 +2125,6 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             )
             assert multiplayer_match is not None
 
-            if userID not in await match.get_referees(multiplayer_match["match_id"]):
-                return None
-
             loop = asyncio.get_running_loop()
             loop.call_later(
                 1.00,
@@ -2109,44 +2137,56 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                 "or you might receive a penalty."
             )
 
-    async def mpInvite() -> Optional[str]:
+    async def mpInvite(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
         if len(message) < 2:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp invite <username>.",
             )
 
-        if not (username := message[1].strip()):
+        username = message[1].strip()
+        if not username:
             raise exceptions.invalidArgumentsException("Please provide a username.")
 
-        if not (userID := await userUtils.getIDSafe(username)):
-            raise exceptions.userNotFoundException("No such user.")
-
-        if not (token := await tokenList.getTokenFromUserID(userID, ignoreIRC=True)):
+        target_token = await tokenList.getTokenFromUsername(username, ignoreIRC=True)
+        if not target_token:
             raise exceptions.invalidUserException(
                 "That user is not connected to Akatsuki right now.",
             )
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
-
         await match.invite(
             multiplayer_match["match_id"],
             fro=CHATBOT_USER_ID,
-            to=userID,
+            to=target_token["user_id"],
         )
 
         await osuToken.enqueue(
-            token["token_id"],
+            target_token["token_id"],
             serverPackets.notification(
                 "Please accept the invite you've just received from "
                 f"{glob.BOT_NAME} to enter your tourney match.",
             ),
         )
+
         return f"An invite to this match has been sent to {username}."
 
-    async def mpMap() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpMap(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if (
             len(message) < 2
@@ -2156,14 +2196,18 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp map <beatmapid> [<gamemode>].",
             )
+
         beatmapID = int(message[1])
         gameMode = int(message[2]) if len(message) == 3 else 0
+
         if gameMode < 0 or gameMode > 3:
             raise exceptions.invalidArgumentsException("Gamemode must be 0, 1, 2 or 3.")
+
         beatmapData = await glob.db.fetch(
             "SELECT song_name, beatmap_md5 FROM beatmaps WHERE beatmap_id = %s LIMIT 1",
             [beatmapID],
         )
+
         if beatmapData is None:
             raise exceptions.invalidArgumentsException(
                 "The beatmap you've selected couldn't be found in the database. "
@@ -2171,27 +2215,32 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                 "order to cache it, then try again.",
             )
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            multiplayer_match = await match.update_match(
+                multiplayer_match["match_id"],
+                beatmap_id=beatmapID,
+                beatmap_name=beatmapData["song_name"],
+                beatmap_md5=beatmapData["beatmap_md5"],
+                game_mode=gameMode,
+            )
+            assert multiplayer_match is not None
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+            await match.resetReady(multiplayer_match["match_id"])
+            await match.sendUpdates(multiplayer_match["match_id"])
 
-        multiplayer_match = await match.update_match(
-            multiplayer_match["match_id"],
-            beatmap_id=beatmapID,
-            beatmap_name=beatmapData["song_name"],
-            beatmap_md5=beatmapData["beatmap_md5"],
-            game_mode=gameMode,
-        )
-        assert multiplayer_match is not None
-        await match.resetReady(multiplayer_match["match_id"])
-        await match.sendUpdates(multiplayer_match["match_id"])
         return "Match map has been updated."
 
-    async def mpSet() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpSet(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if (
             len(message) < 2
@@ -2203,18 +2252,13 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                 "Incorrect syntax: !mp set <teammode> [<scoremode>] [<size>].",
             )
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
-
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
-
         match_team_type = int(message[1])
         match_scoring_type = (
             int(message[2])
             if len(message) >= 3
             else multiplayer_match["match_scoring_type"]
         )
+
         if not 0 <= match_team_type <= 3:
             raise exceptions.invalidArgumentsException(
                 "Match team type must be between 0 and 3.",
@@ -2223,120 +2267,152 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             raise exceptions.invalidArgumentsException(
                 "Match scoring type must be between 0 and 3.",
             )
-        oldMatchTeamType = multiplayer_match["match_team_type"]
-        multiplayer_match = await match.update_match(
-            multiplayer_match["match_id"],
-            match_team_type=match_team_type,
-            match_scoring_type=match_scoring_type,
-        )
-        assert multiplayer_match is not None
 
-        if len(message) >= 4:
-            await match.forceSize(multiplayer_match["match_id"], int(message[3]))
-        if multiplayer_match["match_team_type"] != oldMatchTeamType:
-            await match.initializeTeams(multiplayer_match["match_id"])
-        if (
-            multiplayer_match["match_team_type"] == matchTeamTypes.TAG_COOP
-            or multiplayer_match["match_team_type"] == matchTeamTypes.TAG_TEAM_VS
-        ):
+        oldMatchTeamType = multiplayer_match["match_team_type"]
+
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
             multiplayer_match = await match.update_match(
                 multiplayer_match["match_id"],
-                match_mod_mode=matchModModes.NORMAL,
+                match_team_type=match_team_type,
+                match_scoring_type=match_scoring_type,
             )
             assert multiplayer_match is not None
 
-        await match.sendUpdates(multiplayer_match["match_id"])
+            if (
+                len(message) >= 4
+                and message[3].isnumeric()
+                and 2 <= int(message[3]) <= 16
+            ):
+                await match.forceSize(multiplayer_match["match_id"], int(message[3]))
+
+            if multiplayer_match["match_team_type"] != oldMatchTeamType:
+                await match.initializeTeams(multiplayer_match["match_id"])
+
+            if (
+                multiplayer_match["match_team_type"] == matchTeamTypes.TAG_COOP
+                or multiplayer_match["match_team_type"] == matchTeamTypes.TAG_TEAM_VS
+            ):
+                multiplayer_match = await match.update_match(
+                    multiplayer_match["match_id"],
+                    match_mod_mode=matchModModes.NORMAL,
+                )
+                assert multiplayer_match is not None
+
+            await match.sendUpdates(multiplayer_match["match_id"])
+
         return "Match settings have been updated!"
 
-    async def mpAbort():
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpAbort(user_token: osuToken.Token):
+        if not user_token["match_id"]:
+            return
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
-        await match.abort(multiplayer_match["match_id"])
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            await match.abort(multiplayer_match["match_id"])
+
         return "Match aborted!"
 
-    async def mpKick() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpKick(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if len(message) < 2:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp kick <username>.",
             )
 
-        if not (username := message[1].strip()):
+        username = message[1].strip()
+        if not username:
             raise exceptions.invalidArgumentsException("Please provide a username.")
 
-        if not (userID := await userUtils.getIDSafe(username)):
+        target_token = await osuToken.get_token_by_username(username)
+        if not target_token:
             raise exceptions.userNotFoundException("No such user.")
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
-
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
-
-        if not (
-            slotID := await match.getUserSlotID(multiplayer_match["match_id"], userID)
-        ):
-            raise exceptions.userNotFoundException(
-                "The specified user is not in this match.",
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            slot_id = await match.getUserSlotID(
+                multiplayer_match["match_id"], target_token["user_id"]
             )
+            if not slot_id:
+                raise exceptions.userNotFoundException(
+                    "The specified user is not in this match.",
+                )
 
-        # toggle slot lock twice to kick the user
-        for _ in range(2):
-            await match.toggleSlotLocked(multiplayer_match["match_id"], slotID)
+            # toggle slot lock twice to kick the user
+            for _ in range(2):
+                await match.toggleSlotLocked(multiplayer_match["match_id"], slot_id)
 
-        return f"{username} has been kicked from the match."
+        return f"{target_token['username']} has been kicked from the match."
 
-    async def mpPassword() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpPassword(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
 
-        password = "" if len(message) < 2 or not message[1].strip() else message[1]
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
-        await match.changePassword(multiplayer_match["match_id"], password)
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            password = "" if len(message) < 2 or not message[1].strip() else message[1]
+            await match.changePassword(multiplayer_match["match_id"], password)
+
         return "Match password has been changed!"
 
-    async def mpRandomPassword() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpRandomPassword(
+        user_token: osuToken.Token,
+    ) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
 
-        password = secrets.token_hex(16)
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
-        await match.changePassword(multiplayer_match["match_id"], password)
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            password = secrets.token_hex(16)
+            await match.changePassword(multiplayer_match["match_id"], password)
+
         return "Match password has been randomized."
 
-    async def mpMods() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpMods(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if len(message) != 2 or len(message[1]) % 2:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp mods <mods, e.g. hdhr>",
             )
-
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
-
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
 
         modMap = {
             "NF": mods.NOFAIL,
@@ -2373,66 +2449,85 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
                     or (m == "PF" and _mods & mods.SUDDENDEATH)
                     or (m == "SD" and _mods & mods.PERFECT)
                 ):
-                    _mods |= modMap[m]
+                    _mods |= modMap.get(m, 0)
 
         new_match_mod_mode = (
             matchModModes.FREE_MOD if freemods else matchModModes.NORMAL
         )
-        multiplayer_match = await match.update_match(
-            multiplayer_match["match_id"],
-            match_mod_mode=new_match_mod_mode,
-        )
-        assert multiplayer_match is not None
 
-        await match.resetReady(multiplayer_match["match_id"])
-        if multiplayer_match["match_mod_mode"] == matchModModes.FREE_MOD:
-            await match.resetMods(multiplayer_match["match_id"])
-        await match.changeMods(multiplayer_match["match_id"], _mods)
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            multiplayer_match = await match.update_match(
+                multiplayer_match["match_id"],
+                match_mod_mode=new_match_mod_mode,
+            )
+            assert multiplayer_match is not None
+
+            await match.resetReady(multiplayer_match["match_id"])
+            if multiplayer_match["match_mod_mode"] == matchModModes.FREE_MOD:
+                await match.resetMods(multiplayer_match["match_id"])
+            await match.changeMods(multiplayer_match["match_id"], _mods)
+
         return "Match mods have been updated!"
 
-    async def mpTeam() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpTeam(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if len(message) < 3:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp team <username> <colour>.",
             )
 
-        if not (username := message[1].strip()):
+        if (
+            multiplayer_match["match_team_type"] != matchTeamTypes.TEAM_VS
+            and multiplayer_match["match_team_type"] != matchTeamTypes.TAG_TEAM_VS
+        ):
+            return "Command only available in team vs."
+
+        username = message[1].strip()
+        if not username:
             raise exceptions.invalidArgumentsException("Please provide a username.")
 
-        if (colour := message[2].lower().strip()) not in {"red", "blue"}:
+        colour = message[2].lower().strip()
+        if colour not in {"red", "blue"}:
             raise exceptions.invalidArgumentsException(
                 "Team colour must be red or blue.",
             )
 
-        if not (userID := await userUtils.getIDSafe(username)):
+        colour_const = {"red": matchTeams.RED, "blue": matchTeams.BLUE}[colour]
+
+        target_token = await osuToken.get_token_by_username(username)
+        if not target_token:
             raise exceptions.userNotFoundException("No such user.")
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            await match.changeTeam(
+                multiplayer_match["match_id"],
+                target_token["user_id"],
+                colour_const,
+            )
 
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        return f"{target_token['username']} is now in {colour} team"
 
-        await match.changeTeam(
-            multiplayer_match["match_id"],
-            userID,
-            matchTeams.BLUE if colour == "blue" else matchTeams.RED,
-        )
+    async def mpSettings(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
 
-        return f"{username} is now in {colour} team"
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
 
-    async def mpSettings() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
-
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
-
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         single = False if len(message) < 2 else message[1].strip().lower() == "single"
         msg: list[str] = ["PLAYERS IN THIS MATCH "]
@@ -2490,42 +2585,53 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
 
         return "".join(msg).rstrip(" | " if single else "\n")
 
-    async def mpScoreV() -> Optional[str]:
-        if not (userID := await userUtils.getIDSafe(fro)):
-            raise exceptions.userNotFoundException("No such user")
+    async def mpScoreV(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
+
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        referees = await match.get_referees(multiplayer_match["match_id"])
+        if user_token["user_id"] not in referees:
+            return
 
         if len(message) < 2 or message[1] not in {"1", "2"}:
             raise exceptions.invalidArgumentsException(
                 "Incorrect syntax: !mp scorev <1|2>.",
             )
 
-        multiplayer_match = await matchList.getMatchFromChannel(chan)
-        assert multiplayer_match is not None
-
-        if userID not in await match.get_referees(multiplayer_match["match_id"]):
-            return None
-
         if message[1] == "2":
             new_scoring_type = matchScoringTypes.SCORE_V2
         else:
             new_scoring_type = matchScoringTypes.SCORE
 
-        multiplayer_match = await match.update_match(
-            multiplayer_match["match_id"],
-            match_scoring_type=new_scoring_type,
-        )
-        assert multiplayer_match is not None
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+            multiplayer_match = await match.update_match(
+                multiplayer_match["match_id"],
+                match_scoring_type=new_scoring_type,
+            )
+            assert multiplayer_match is not None
 
-        await match.sendUpdates(multiplayer_match["match_id"])
+            await match.sendUpdates(multiplayer_match["match_id"])
+
         return f"Match scoring type set to scorev{message[1]}."
 
-    async def mpHelp() -> Optional[str]:
+    async def mpHelp(_: osuToken.Token) -> Optional[str]:
         return f"Supported multiplayer subcommands: <{' | '.join(subcommands.keys())}>."
 
-    async def mp_link() -> Optional[str]:
-        match_id = await channelList.getMatchIDFromChannel(chan)
-        mp_message = await match.get_match_history_message(match_id)
+    async def mp_link(user_token: osuToken.Token) -> Optional[str]:
+        if not user_token["match_id"]:
+            return
 
+        multiplayer_match = await match.get_match(user_token["match_id"])
+        if multiplayer_match is None:
+            return
+
+        mp_message = await match.get_match_history_message(
+            multiplayer_match["match_id"]
+        )
         return mp_message
 
     try:
@@ -2535,7 +2641,6 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
             "listref": mpListRefer,
             "make": mpMake,
             "close": mpClose,
-            # "join": mpJoin,
             "force": mpForce,
             "lock": mpLock,
             "unlock": mpUnlock,
@@ -2562,7 +2667,7 @@ async def multiplayer(fro: str, chan: str, message: list[str]) -> Optional[str]:
         requestedSubcommand = message[0].lower().strip()
         if requestedSubcommand not in subcommands:
             raise exceptions.invalidArgumentsException("Invalid subcommand.")
-        return await subcommands[requestedSubcommand]()
+        return await subcommands[requestedSubcommand](_user_token)
     except (
         exceptions.invalidArgumentsException,
         exceptions.userNotFoundException,

--- a/events/changeMatchModsEvent.py
+++ b/events/changeMatchModsEvent.py
@@ -17,7 +17,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
         return None
 
     # Set slot or match mods according to modType
-    async with redisLock(f"{match.make_key(match_id)}:lock"):
+    async with redisLock(match.make_lock_key(match_id)):
         # Make sure the match exists
         multiplayer_match = await match.get_match(match_id)
         if multiplayer_match is None:

--- a/events/changeMatchPasswordEvent.py
+++ b/events/changeMatchPasswordEvent.py
@@ -14,7 +14,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
     if match_id is None:
         return
 
-    async with redisLock(f"{match.make_key(match_id)}:lock"):
+    async with redisLock(match.make_lock_key(match_id)):
         # Make sure the match exists
         multiplayer_match = await match.get_match(match_id)
         if multiplayer_match is None:

--- a/events/changeMatchSettingsEvent.py
+++ b/events/changeMatchSettingsEvent.py
@@ -19,7 +19,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
     if match_id is None:
         return
 
-    async with redisLock(f"{match.make_key(match_id)}:lock"):
+    async with redisLock(match.make_lock_key(match_id)):
         # Make sure the match exists
         multiplayer_match = await match.get_match(match_id)
         if multiplayer_match is None:

--- a/events/changeMatchSettingsEvent.py
+++ b/events/changeMatchSettingsEvent.py
@@ -65,7 +65,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
 
         if old_match_name != multiplayer_match["match_name"]:
             await channelList.updateChannel(
-                f"#multi_{multiplayer_match['match_id']}",
+                f"#mp_{multiplayer_match['match_id']}",
                 description=f"Multiplayer lobby for match {multiplayer_match['match_name']}",
             )
 

--- a/events/changeSlotEvent.py
+++ b/events/changeSlotEvent.py
@@ -13,7 +13,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
 
     packetData = clientPackets.changeSlot(rawPacketData)
 
-    async with redisLock(f"{match.make_key(match_id)}:lock"):
+    async with redisLock(match.make_lock_key(match_id)):
         multiplayer_match = await match.get_match(match_id)
         if multiplayer_match is None:
             return

--- a/events/createMatchEvent.py
+++ b/events/createMatchEvent.py
@@ -44,7 +44,7 @@ async def handle(token: osuToken.Token, rawPacketData: bytes):
             await match.setHost(multiplayer_match["match_id"], token["user_id"])
             await match.sendUpdates(multiplayer_match["match_id"])
             await match.changePassword(
-                multiplayer_match["match_id"], packetData["matchPassword"]
+                multiplayer_match["match_id"], packetData["matchPassword"],
             )
 
         if glob.amplitude is not None:

--- a/events/createMatchEvent.py
+++ b/events/createMatchEvent.py
@@ -44,7 +44,8 @@ async def handle(token: osuToken.Token, rawPacketData: bytes):
             await match.setHost(multiplayer_match["match_id"], token["user_id"])
             await match.sendUpdates(multiplayer_match["match_id"])
             await match.changePassword(
-                multiplayer_match["match_id"], packetData["matchPassword"],
+                multiplayer_match["match_id"],
+                packetData["matchPassword"],
             )
 
         if glob.amplitude is not None:

--- a/events/createMatchEvent.py
+++ b/events/createMatchEvent.py
@@ -26,7 +26,7 @@ async def handle(token: osuToken.Token, rawPacketData: bytes):
 
         # Create a match object
         # TODO: Player number check
-        match_id = await matchList.createMatch(
+        multiplayer_match = await matchList.createMatch(
             match_name,
             packetData["matchPassword"].strip(),
             packetData["beatmapID"],
@@ -36,19 +36,16 @@ async def handle(token: osuToken.Token, rawPacketData: bytes):
             token["user_id"],
         )
 
-        async with redisLock(f"{match.make_key(match_id)}:lock"):
-            # Make sure the match has been created
-            multiplayer_match = await match.get_match(match_id)
-            if multiplayer_match is None:
-                raise exceptions.matchCreateError()
-
+        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
             # Join that match
-            await osuToken.joinMatch(token["token_id"], match_id)
+            await osuToken.joinMatch(token["token_id"], multiplayer_match["match_id"])
 
             # Give host to match creator
-            await match.setHost(match_id, token["user_id"])
-            await match.sendUpdates(match_id)
-            await match.changePassword(match_id, packetData["matchPassword"])
+            await match.setHost(multiplayer_match["match_id"], token["user_id"])
+            await match.sendUpdates(multiplayer_match["match_id"])
+            await match.changePassword(
+                multiplayer_match["match_id"], packetData["matchPassword"]
+            )
 
         if glob.amplitude is not None:
             amplitude_event_props = {

--- a/events/createMatchEvent.py
+++ b/events/createMatchEvent.py
@@ -36,7 +36,7 @@ async def handle(token: osuToken.Token, rawPacketData: bytes):
             token["user_id"],
         )
 
-        async with redisLock(f"{match.make_key(multiplayer_match['match_id'])}:lock"):
+        async with redisLock(match.make_lock_key(multiplayer_match["match_id"])):
             # Join that match
             await osuToken.joinMatch(token["token_id"], multiplayer_match["match_id"])
 

--- a/events/joinMatchEvent.py
+++ b/events/joinMatchEvent.py
@@ -18,7 +18,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
     matchID = packetData["matchID"]
     password = packetData["password"]
 
-    async with redisLock(f"{match.make_key(matchID)}:lock"):
+    async with redisLock(match.make_lock_key(matchID)):
         # Make sure the match exists
         multiplayer_match = await match.get_match(matchID)
         if multiplayer_match is None:

--- a/events/matchBeatmapEvent.py
+++ b/events/matchBeatmapEvent.py
@@ -10,7 +10,7 @@ async def handle(userToken: Token, _, has_beatmap: bool):
     if userToken["match_id"] is None:
         return
 
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchChangeTeamEvent.py
+++ b/events/matchChangeTeamEvent.py
@@ -11,7 +11,7 @@ async def handle(userToken: Token, _):
         return
 
     # Change team
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchCompleteEvent.py
+++ b/events/matchCompleteEvent.py
@@ -11,7 +11,7 @@ async def handle(userToken: Token, _):
         return
 
     # Set our match complete
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchFailedEvent.py
+++ b/events/matchFailedEvent.py
@@ -11,7 +11,7 @@ async def handle(userToken: Token, _):
         return
 
     # Fail user
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchFramesEvent.py
+++ b/events/matchFramesEvent.py
@@ -16,7 +16,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
     # Parse the data
     packetData = clientPackets.matchFrames(rawPacketData)
 
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchInviteEvent.py
+++ b/events/matchInviteEvent.py
@@ -12,7 +12,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
         return
 
     # Send invite
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchLockEvent.py
+++ b/events/matchLockEvent.py
@@ -13,7 +13,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
     if userToken["match_id"] is None:
         return
 
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchPlayerLoadEvent.py
+++ b/events/matchPlayerLoadEvent.py
@@ -11,7 +11,7 @@ async def handle(userToken: Token, _):
         return
 
     # Set our load status
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchReadyEvent.py
+++ b/events/matchReadyEvent.py
@@ -9,7 +9,7 @@ async def handle(userToken: Token, _):
     if userToken["match_id"] is None:
         return
 
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchSkipEvent.py
+++ b/events/matchSkipEvent.py
@@ -11,7 +11,7 @@ async def handle(userToken: Token, _):
         return
 
     # Skip
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchStartEvent.py
+++ b/events/matchStartEvent.py
@@ -13,7 +13,7 @@ async def handle(userToken: Token, _):
     if userToken["match_id"] is None:
         return
 
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/matchTransferHostEvent.py
+++ b/events/matchTransferHostEvent.py
@@ -13,7 +13,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
 
     packetData = clientPackets.transferHost(rawPacketData)
 
-    async with redisLock(f"{match.make_key(userToken['match_id'])}:lock"):
+    async with redisLock(match.make_lock_key(userToken["match_id"])):
         # Make sure the match exists
         multiplayer_match = await match.get_match(userToken["match_id"])
         if multiplayer_match is None:

--- a/events/tournamentJoinMatchChannelEvent.py
+++ b/events/tournamentJoinMatchChannelEvent.py
@@ -22,6 +22,6 @@ async def handle(userToken: Token, rawPacketData: bytes):
 
     await chat.joinChannel(
         token_id=userToken["token_id"],
-        channel_name=f'#multi_{packetData["matchID"]}',
+        channel_name=f'#mp_{packetData["matchID"]}',
         force=True,
     )

--- a/events/tournamentLeaveMatchChannelEvent.py
+++ b/events/tournamentLeaveMatchChannelEvent.py
@@ -17,7 +17,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
 
     await chat.partChannel(
         token_id=userToken["token_id"],
-        channel_name=f'#multi_{packetData["matchID"]}',
+        channel_name=f'#mp_{packetData["matchID"]}',
         force=True,
     )
 

--- a/events/tournamentMatchInfoRequestEvent.py
+++ b/events/tournamentMatchInfoRequestEvent.py
@@ -13,7 +13,7 @@ async def handle(userToken: Token, rawPacketData: bytes):
 
     match_id = packetData["matchID"]
 
-    async with redisLock(f"{match.make_key(match_id)}:lock"):
+    async with redisLock(match.make_lock_key(match_id)):
         multiplayer_match = await match.get_match(match_id)
         if multiplayer_match is None or not userToken["tournament"]:
             return

--- a/helpers/chatHelper.py
+++ b/helpers/chatHelper.py
@@ -39,7 +39,7 @@ async def joinChannel(
     :param token: user token object of user that joins the channel. Optional. userID can be used instead.
     :param channel: channel name
     :param toIRC: if True, send this channel join event to IRC. Must be true if joining from bancho. Default: True
-    :param force: whether to allow game clients to join #spect_ and #multi_ channels
+    :param force: whether to allow game clients to join #spect_ and #mp_ channels
     :return: 0 if joined or other IRC code in case of error. Needed only on IRC-side
     """
     token: Optional[osuToken.Token] = None
@@ -61,7 +61,7 @@ async def joinChannel(
         if channel_name not in await channelList.getChannelNames():
             raise exceptions.channelUnknownException()
 
-        # Make sure a game client is not trying to join a #multi_ or #spect_ channel manually
+        # Make sure a game client is not trying to join a #mp_ or #spect_ channel manually
         channel = await channelList.getChannel(channel_name)
         if channel is None:
             raise exceptions.channelUnknownException()
@@ -142,7 +142,7 @@ async def partChannel(
     :param channel: channel name
     :param toIRC: if True, send this channel join event to IRC. Must be true if joining from bancho. Optional. Default: True
     :param kick: if True, channel tab will be closed on client. Used when leaving lobby. Optional. Default: False
-    :param force: whether to allow game clients to part #spect_ and #multi_ channels
+    :param force: whether to allow game clients to part #spect_ and #mp_ channels
     :return: 0 if joined or other IRC code in case of error. Needed only on IRC-side
     """
     token: Optional[osuToken.Token] = None
@@ -173,17 +173,17 @@ async def partChannel(
                 spectating_user_id = token["spectating_user_id"]
             channel_name = f"#spect_{spectating_user_id}"
         elif channel_name == "#multiplayer":
-            channel_name = f"#multi_{token['match_id']}"
+            channel_name = f"#mp_{token['match_id']}"
         elif channel_name.startswith("#spect_"):
             channelClient = "#spectator"
-        elif channel_name.startswith("#multi_"):
+        elif channel_name.startswith("#mp_"):
             channelClient = "#multiplayer"
 
         # Make sure the channel exists
         if channel_name not in await channelList.getChannelNames():
             raise exceptions.channelUnknownException()
 
-        # Make sure a game client is not trying to join a #multi_ or #spect_ channel manually
+        # Make sure a game client is not trying to join a #mp_ or #spect_ channel manually
         channel = await channelList.getChannel(channel_name)
         if channel is None:
             raise exceptions.channelUnknownException()
@@ -322,10 +322,10 @@ async def sendMessage(
                 s = userToken["spectating_user_id"]
             to = f"#spect_{s}"
         elif to == "#multiplayer":
-            to = f"#multi_{userToken['match_id']}"
+            to = f"#mp_{userToken['match_id']}"
         elif to.startswith("#spect_"):
             toClient = "#spectator"
-        elif to.startswith("#multi_"):
+        elif to.startswith("#mp_"):
             toClient = "#multiplayer"
 
         isChannel = to[0] == "#"
@@ -377,7 +377,7 @@ async def sendMessage(
             # non-public channels (except multiplayer) require staff or bot
             if (
                 not channel["public_write"]
-                and not (to.startswith("#multi_") or to.startswith("#spect_"))
+                and not (to.startswith("#mp_") or to.startswith("#spect_"))
             ) and not (
                 osuToken.is_staff(userToken["privileges"])
                 or userToken["user_id"] == CHATBOT_USER_ID

--- a/objects/channelList.py
+++ b/objects/channelList.py
@@ -210,7 +210,7 @@ async def updateChannel(
 
 
 async def getMatchIDFromChannel(channel_name: str) -> int:
-    if not channel_name.lower().startswith("#multi_"):
+    if not channel_name.lower().startswith("#mp_"):
         raise exceptions.wrongChannelException()
 
     parts = channel_name.lower().split("_")

--- a/objects/match.py
+++ b/objects/match.py
@@ -66,6 +66,7 @@ class Match(TypedDict):
 def make_key(match_id: int) -> str:
     return f"bancho:matches:{match_id}"
 
+
 def make_lock_key(match_id: int) -> str:
     return f"bancho:matches:{match_id}:lock"
 

--- a/objects/match.py
+++ b/objects/match.py
@@ -689,7 +689,7 @@ async def allPlayersCompleted(match_id: int) -> None:
     # Console output
     # log.info("MPROOM{}: Match completed".format(self.matchID))
 
-    channel_name = f"#multi_{match_id}"
+    channel_name = f"#mp_{match_id}"
 
     # If this is a tournament match, then we send a notification in the chat
     # saying that the match has completed.
@@ -1401,7 +1401,7 @@ async def resetReady(match_id: int) -> None:
 
 
 async def sendReadyStatus(match_id: int) -> None:
-    channel_name = f"#multi_{match_id}"
+    channel_name = f"#mp_{match_id}"
 
     # Make sure match exists before attempting to do anything else
     if channel_name not in await channelList.getChannelNames():

--- a/objects/match.py
+++ b/objects/match.py
@@ -66,6 +66,9 @@ class Match(TypedDict):
 def make_key(match_id: int) -> str:
     return f"bancho:matches:{match_id}"
 
+def make_lock_key(match_id: int) -> str:
+    return f"bancho:matches:{match_id}:lock"
+
 
 async def create_match(
     match_name: str,

--- a/objects/matchList.py
+++ b/objects/matchList.py
@@ -28,7 +28,7 @@ async def createMatch(
     game_mode: int,
     host_user_id: int,
     is_tourney: bool = False,
-) -> int:
+) -> match.Match:
     """
     Add a new match to matches list
 
@@ -67,7 +67,7 @@ async def createMatch(
         match.create_playing_stream_name(multiplayer_match["match_id"]),
     )
     await channelList.addChannel(
-        f"#multi_{multiplayer_match['match_id']}",
+        f"#mp_{multiplayer_match['match_id']}",
         description=f"Multiplayer lobby for match {multiplayer_match['match_name']}",
         public_read=True,
         public_write=False,
@@ -75,7 +75,7 @@ async def createMatch(
         instance=True,
     )
 
-    return multiplayer_match["match_id"]
+    return multiplayer_match
 
 
 async def disposeMatch(match_id: int) -> None:
@@ -107,7 +107,7 @@ async def disposeMatch(match_id: int) -> None:
             )
 
     # Delete chat channel
-    await channelList.removeChannel(f"#multi_{match_id}")
+    await channelList.removeChannel(f"#mp_{match_id}")
 
     stream_name = match.create_stream_name(match_id)
     playing_stream_name = match.create_playing_stream_name(match_id)

--- a/objects/osuToken.py
+++ b/objects/osuToken.py
@@ -800,7 +800,7 @@ async def joinMatch(token_id: str, match_id: int) -> bool:
     await joinStream(token_id, match.create_stream_name(multiplayer_match["match_id"]))
     await chat.joinChannel(
         token_id=token_id,
-        channel_name=f"#multi_{match_id}",
+        channel_name=f"#mp_{match_id}",
         force=True,
     )
     await enqueue(token_id, await serverPackets.matchJoinSuccess(match_id))
@@ -849,7 +849,7 @@ async def leaveMatch(token_id: str) -> None:
     # Part #multiplayer channel and streams (/ and /playing)
     await chat.partChannel(
         token_id=token_id,
-        channel_name=f"#multi_{token['match_id']}",
+        channel_name=f"#mp_{token['match_id']}",
         kick=True,
         force=True,
     )


### PR DESCRIPTION
Referring to #110, it turns out that not only `!mp start` command was broken, but the rest of the commands were also either bloated, unusable or broken in some ways.

This PR is a collection of fixes to the commands while also making them usable for normal players now (bancho also allows for that).
I also decided to rename `#multi_` channel names to `#mp_` to allow for bancho-like IRC experience