### PR TITLE
Remove redundant checks on stream broadcast

### DIFF
--- a/objects/stream.py
+++ b/objects/stream.py
@@ -68,14 +68,10 @@ async def broadcast(stream_name: str, data: bytes, but: list[str] = []) -> None:
     :return:
     """
     current_tokens = await getClients(stream_name)
-    token_ids = await osuToken.get_token_ids()
 
     for i in current_tokens:
-        if i in token_ids:
-            if i not in but:
-                await osuToken.enqueue(i, data)
-        else:
-            await removeClient(stream_name, token_id=i)
+        if i not in but:
+            await osuToken.enqueue(i, data)
 
 
 async def broadcast_limited(stream_name: str, data: bytes, users: list[str]) -> None:
@@ -89,11 +85,8 @@ async def broadcast_limited(stream_name: str, data: bytes, users: list[str]) -> 
     current_tokens = await getClients(stream_name)
 
     for i in current_tokens:
-        if i in await osuToken.get_token_ids():
-            if i in users:
-                await osuToken.enqueue(i, data)
-        else:
-            await removeClient(stream_name, token_id=i)
+        if i in users:
+            await osuToken.enqueue(i, data)
 
 
 async def dispose(stream_name: str) -> None:


### PR DESCRIPTION
Small wins in attempt to try and improve responsiveness of spectator packets. when mrekk comes on (like rn) it basically dies...

These checks are small but useful to remove, `enqueue` already checks for token existence so there's no need for these.