### PR TITLE
Fix/support /np parsing where beatmap id is not present

### DIFF
--- a/constants/chatbotCommands.py
+++ b/constants/chatbotCommands.py
@@ -821,7 +821,7 @@ async def tillerinoNp(fro: str, chan: str, message: list[str]) -> str | None:
             SELECT beatmap_id
             FROM beatmaps
             WHERE beatmapset_id = %s
-            ORDER BY last_update DESC
+            ORDER BY beatmap_id DESC
             LIMIT 1
             """,
             [beatmapset_id],

--- a/objects/chatbot.py
+++ b/objects/chatbot.py
@@ -26,7 +26,7 @@ USERNAME_REGEX = re.compile(r"^[\w \[\]-]{2,15}$")
 NOW_PLAYING_REGEX = re.compile(
     r"^(?P<action_type>playing|editing|watching|listening to) "
     rf"\[https://osu\.(?:akatsuki\.pw|akatsuki\.gg|akatest\.space|ppy\.sh)/beatmapsets/"
-    rf"(?P<sid>\d{{1,10}})#/?(?:osu|taiko|fruits|mania)?/(?P<bid>\d{{1,10}})/? .+\]"
+    rf"(?P<sid>\d{{1,10}})#?/?(?:osu|taiko|fruits|mania)?(?:/(?P<bid>\d{{1,10}}))?/? .+\]"
     r"(?: <(?P<mode_vn>Taiko|CatchTheBeat|osu!mania)>)?"
     # TODO: don't include the space at the start of mods
     r"(?P<mods>(?: (?:-|\+|~|\|)\w+(?:~|\|)?)+)?\x01$",


### PR DESCRIPTION
Fixes this case, where beatmap id is not present (only set id):

![image](https://i.cmyui.xyz/jlxY3-5gX3iDd2Nc6t4zIA.png)

Reported by BN team here: https://discord.com/channels/365406575893938177/714659303075741806/1242444436084887552